### PR TITLE
add options: `strict` and `keep_special_kwargs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ if __name__ == "__main__":
         warn_overwrites=True, # warn repeating args if they are allowed
         parse_env=True, # get environment variable
         warn_env=True, # warn if an environment variable is specified but not found
+        defaults=None, # path to a MinyDict-loadable dictionary of default values for the args
+        strict=True, # if `defaults` is provided, whether to allow new keys in the command-line
+                     # or restrict to `defaults`' keys
+        keep_special_kwargs=True, # `defaults` and `strict` can be set from the command-line
+                                  # with `@defaults=` and `@strict=`. This argument decides if
+                                  # you want to keep those keys in the final arguments.
     )
     args = parser.args.pretty_print().resolve().pretty_print() # notice .resolve() transforms dotted.keys into nested dicts
 ```

--- a/minydra/__init__.py
+++ b/minydra/__init__.py
@@ -11,6 +11,8 @@ def parse_args(
     parse_env=True,
     warn_env=True,
     defaults=None,
+    strict=True,
+    keep_special_kwargs=True,
 ):
     def decorator(function):
         def wrapper(*args, **kwargs):
@@ -21,6 +23,8 @@ def parse_args(
                 parse_env=parse_env,
                 warn_env=warn_env,
                 defaults=defaults,
+                strict=strict,
+                keep_special_kwargs=keep_special_kwargs,
             )
             result = function(parser.args)
             return result
@@ -37,6 +41,8 @@ def resolved_args(
     parse_env=True,
     warn_env=True,
     defaults=None,
+    strict=True,
+    keep_special_kwargs=True,
 ):
     return Parser(
         verbose=verbose,
@@ -45,4 +51,6 @@ def resolved_args(
         parse_env=parse_env,
         warn_env=warn_env,
         defaults=defaults,
+        strict=strict,
+        keep_special_kwargs=keep_special_kwargs,
     ).args.resolve()

--- a/tests/test_minydra.py
+++ b/tests/test_minydra.py
@@ -74,6 +74,24 @@ def test_defaults():
             del args["@defaults"]
             assert args.to_dict() == json.loads(d1.read_text())
 
+    with patch.object(
+        sys, "argv", ["", f"@defaults={str(d1)}", "@strict=false", "new_key=3"]
+    ):
+        args = minydra.resolved_args(keep_special_kwargs=False)
+        target = json.loads(d1.read_text())
+        target["new_key"] = 3
+        assert args.to_dict() == target
+
+    with patch.object(
+        sys, "argv", ["", f"@defaults={str(d1)}", "@strict=false", "new_key=3"]
+    ):
+        args = minydra.resolved_args()
+        del args["@defaults"]
+        del args["@strict"]
+        target = json.loads(d1.read_text())
+        target["new_key"] = 3
+        assert args.to_dict() == target
+
     double_defaults = f"['{str(d1)}', '{str(d2)}']"
     with patch.object(sys, "argv", ["", f"@defaults={double_defaults}", "new_key=3"]):
         args = minydra.resolved_args()


### PR DESCRIPTION
## New options

```python
class Parser:

	...

    def __init__(
        self,
        verbose=0,
        allow_overwrites=False,
        warn_overwrites=True,
        parse_env=True,
        warn_env=True,
        defaults=None,
        strict=True, # <---
        keep_special_kwargs=True, # <---
    ) -> None:
```

* `strict` allows for using `defaults` without constraining command-line arguments to its keys
* `keep_special_kwargs` allows for automatic removal of `minydra`'s special keyword arguments `@defaults` and `@strict` from the final args

## Tests

New tests for those options:

```python
	
	# test_parser.py

    with patch.object(
        sys, "argv", ["", f"@defaults={str(d1)}", "@strict=false", "new_key=3"]
    ):
        args = minydra.resolved_args(keep_special_kwargs=False)
        target = json.loads(d1.read_text())
        target["new_key"] = 3
        assert args.to_dict() == target

    with patch.object(
        sys, "argv", ["", f"@defaults={str(d1)}", "@strict=false", "new_key=3"]
    ):
        args = minydra.resolved_args()
        del args["@defaults"]
        del args["@strict"]
        target = json.loads(d1.read_text())
        target["new_key"] = 3
        assert args.to_dict() == target
```