### PR TITLE
Automatic `@` special args parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,44 @@ In [3]: Parser.type_separator
 Out[3]: '___'
 ```
 
+<br/>
+
+### Command-line configuration
+
+You can configure the `Parser` from the command-line using special `@` arguments. In other words, all `__init__(self, ...)` arguments can be set from the command-line with `@argname=new_value`.
+
+In particular if you run `python examples/decorator.py @defaults=./examples/demo.json` you will see:
+
+```
+╭──────────────────────────────────────╮
+│ @defaults : ./examples/demo.json     │
+│ log                                  │
+│ │logger                              │
+│ │ │log_level   : DEBUG               │
+│ │ │logger_name : minydra             │
+│ │outdir  : /some/path                │
+│ │project : demo                      │
+│ verbose   : False                    │
+╰──────────────────────────────────────╯
+```
+
+**But** if you add `@strict=false @keep_special_kwargs=false` you will now have:
+
+```
+$ python examples/decorator.py @defaults=./examples/demo.json @strict=false @keep_special_kwargs=false
+╭──────────────────────────────╮
+│ log                          │
+│ │logger                      │
+│ │ │log_level   : DEBUG       │
+│ │ │logger_name : minydra     │
+│ │outdir  : /some/path        │
+│ │project : demo              │
+│ verbose : False              │
+╰──────────────────────────────╯
+```
+
+(*you need to have `@strict=false` since `@keep_special_kwargs` is unknown in `demo.json`. It would not be the case if `strict=false` had been used in the script itself (but it can be overridden from the command-line!)*)
+
 <br/><br/>
 
 ## MinyDict
@@ -349,10 +387,11 @@ The `minydra.Parser` class takes a `defaults=` keyword argument. This can be:
 
 * a `str` or a `pathlib.Path` to a `json` `yaml` or `pickle` file that `minydra.MinyDict` can load (`from_X`)
 * a `dict` or a `minydra.MinyDict`
+* a `list` of the above types, in which case the resulting defaults will be the result of sequential updates from those defaults, enabling hierarchical defaults (first defaults are the starting point, then each subsequent defaults updates it)
 
 When `defaults` is provided, the resulting `minydra.MinyDict` serves as a reference for the arguments parsed from the command-line:
 
-* arguments from the command-line have a higher priority but **must** be present in the `defaults` (`defaults.update(args, strict=True)` is used, see [strict mode](#strict-mode))
+* **If** you setup the parser with `strict=True`, arguments from the command-line will still have a higher priority but they will **have to** be present in the `defaults` to prevent typos or unknown arguments (see [strict mode](#strict-mode))
 * arguments not present in the command-line with fallback to values in `defaults`
 
 `defaults` can actually be a `list` and the update order is the same as the list's. For instance:

--- a/minydra/__init__.py
+++ b/minydra/__init__.py
@@ -1,7 +1,7 @@
 from .dict import MinyDict  # noqa: F401
 from .parser import Parser
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 
 def parse_args(

--- a/minydra/parser.py
+++ b/minydra/parser.py
@@ -69,7 +69,9 @@ class Parser:
         super().__init__()
 
         self.conf = MinyDict()
-
+        # store initial arguments in a conf object to be able to
+        # retrieve them later and most importantly to be able to
+        # parse them in the `_parse_conf()` method
         self.conf.verbose = verbose
         self.conf.allow_overwrites = allow_overwrites
         self.conf.warn_overwrites = warn_overwrites
@@ -83,27 +85,34 @@ class Parser:
         self._parse_args()
         self._print("sys.argv:", self._argv)
 
+        # defaults are provided
         if self.conf.defaults is not None or self.args["@defaults"]:
+            # load defaults as a MinyDict
             default = self.load_defaults(self.args["@defaults"] or self.conf.defaults)
+            # resolve existing args to properly override nested defaults
             args = self.args.deepcopy().resolve()
 
             args_defaults = args["@defaults"]
             args_strict = args["@strict"]
 
+            # clean args
             if args_defaults is not None:
                 del args["@defaults"]
             if args_strict is not None:
                 self.conf.strict = args["@strict"]
                 del args["@strict"]
 
+            # update defaults from command-line args
             self.args = default.update(args, strict=self.conf.strict)
 
+            # bring back special (@) kwargs if need be
             if self.conf.keep_special_kwargs:
                 if args_defaults is not None:
                     self.args["@defaults"] = args_defaults
                 if args_strict is not None:
                     self.args["@strict"] = args_strict
 
+        # clean up special (@) kwargs if need be
         if not self.conf.keep_special_kwargs:
             for k in self.conf:
                 self.args.pop(f"@{k}", None)
@@ -111,27 +120,44 @@ class Parser:
     @staticmethod
     def load_defaults(default: Union[str, dict, MinyDict]):
         """
-        Set the default keys.
+        Set the default keys from `defaults`:
+
+        * str/path -> must point to a yaml/json/pickle file then
+            MinyDict.from_X will be used
+        * dict -> Convert that dictionnary to a resolved MinyDict
+        * list -> Recursively calls load_defaults on each element, then
+            sequentially update an (initially empty) MinyDict to allow
+            for hierarchical defaults.
 
         Args:
             allow (Union[str, dict, MinyDict]): The set of allowed keys as a
                 (Miny)dict or a path to a file that `minydra.MinyDict` will be able to
                 load (as `json`, `pickle` or `yaml`)
         """
+        # `defaults` is a path: load it with MinyDict.from_X
         if isinstance(default, (str, pathlib.Path)):
+            # resolve path to file
             default = resolve_path(default)
+            # ensure it exists
             assert default.exists()
             assert default.is_file()
+            # check for known file formats
             if default.suffix not in {".json", ".yaml", ".yml", ".pickle", ".pkl"}:
                 raise ValueError(f"{str(default)} is not a valid file extension.")
+            # Load from YAML
             if default.suffix in {".yaml", ".yml"}:
                 default = MinyDict.from_yaml(default)
+            # Load from Pickle
             elif default.suffix in {".pickle", ".pkl"}:
                 default = MinyDict.from_pickle(default)
+            # Load from JSON
             else:
                 default = MinyDict.from_json(default)
+        # `defaults` is a dictionnary: convert it to a resolved MinyDict
         elif isinstance(default, dict):
             default = MinyDict(default).resolve()
+        # `defaults` is a list: recursively call load_defaults on each element
+        # then sequentially merge all dictionaries to enable hierarchical defaults
         elif isinstance(default, list):
             defaults = [Parser.load_defaults(d) for d in default]
             default = MinyDict()
@@ -146,26 +172,38 @@ class Parser:
             print(*args, **kwargs)
 
     def _parse_args(self):
+        # check arguments syntax
         Parser.check_args(self._argv)
+        # edit configuration to use the command-line special (@) arguments
         self._parse_conf()
+        # create a dictionary from the command-line string arguments
         args = Parser.map_argv(
             self._argv, self.conf.allow_overwrites, self.conf.warn_overwrites
         )
+        # parse the dictionary's values into known types
         args = Parser.parse_arg_types(args, self.conf.parse_env, self.conf.warn_env)
 
+        # store the parsed & typed arguments in a MinyDict
         self.args = MinyDict(**args)
 
     def _parse_conf(self):
+        # find all potentially overridable arguments
         special_keys = [f"@{k}" for k in self.conf.keys()]
+        # find all minydra-specific command-line args:
+        # they must start with an "@" AND be in special_keys
+        # so that @unknown=4 will be kept as an argument, not a configuration
+        # argument.
         command_line_special_keys = [
             arg for arg in self._argv if arg.split("=")[0] in special_keys
         ]
+        # No special (@) arguments: nothing to do
         if len(command_line_special_keys) == 0:
             return
-
+        # create a dictionary of special (@) arguments ({key:value})
         mapped_specials = Parser.map_argv(command_line_special_keys, False, False)
+        # parse the dictionary's values into known types
         parsed_specials = Parser.parse_arg_types(mapped_specials, True, True)
-
+        # override conf from special (@) command-line arguments
         self.conf.update({k[1:]: v for k, v in parsed_specials.items()})
 
     @staticmethod

--- a/tests/test_minydra.py
+++ b/tests/test_minydra.py
@@ -100,3 +100,47 @@ def test_defaults():
         d1d = d1d.update(d2d)
         del args["@defaults"]
         assert args == d1d
+
+
+def test_auto_kwargs():
+    examples = Path(__file__).resolve().parent.parent / "examples"
+    d1 = examples / "demo.json"
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "",
+            "@verbose=1",
+            "@allow_overwrites=True",
+            "@warn_overwrites=False",
+            "@parse_env=False",
+            "@warn_env=False",
+            f"@defaults={str(d1)}",
+            "@strict=False",
+            "@keep_special_kwargs=False",
+            "new_key=3",
+        ],
+    ):
+        parser = minydra.Parser(
+            verbose=0,
+            allow_overwrites=False,
+            warn_overwrites=True,
+            parse_env=True,
+            warn_env=True,
+            defaults=None,
+            strict=True,
+            keep_special_kwargs=True,
+        )
+        args = parser.args.resolve()
+
+        assert parser.conf.verbose == 1
+        assert parser.conf.allow_overwrites is True
+        assert parser.conf.warn_overwrites is False
+        assert parser.conf.parse_env is False
+        assert parser.conf.warn_env is False
+        assert parser.conf.strict is False
+        assert parser.conf.keep_special_kwargs is False
+
+        target = json.loads(d1.read_text())
+        target["new_key"] = 3
+        assert args.to_dict() == target

--- a/tests/test_parser_static.py
+++ b/tests/test_parser_static.py
@@ -35,44 +35,44 @@ def test_check_args():
         Parser.check_args([".p=2"])
 
 
-def test_simple_map_args(capfd):
+def test_simple_map_argv(capfd):
     args = ["a=2"]
-    assert Parser.map_args(args, True, False) == {"a": "2"}
+    assert Parser.map_argv(args, True, False) == {"a": "2"}
 
 
-def test_map_args_overwrite_warn(capfd):
+def test_map_argv_overwrite_warn(capfd):
     args = ["a=2", "a=3"]
-    assert Parser.map_args(args, True, True) == {"a": "3"}
+    assert Parser.map_argv(args, True, True) == {"a": "3"}
     out, err = capfd.readouterr()
     assert "Repeated argument a" in out
 
 
-def test_map_args_overwrite_no_warn(capfd):
+def test_map_argv_overwrite_no_warn(capfd):
     args = ["a=2", "a=3"]
-    assert Parser.map_args(args, True, False) == {"a": "3"}
+    assert Parser.map_argv(args, True, False) == {"a": "3"}
     out, err = capfd.readouterr()
     assert not out
 
 
-def test_map_args_no_overwrite(capfd):
+def test_map_argv_no_overwrite(capfd):
     args = ["a=2", "a=3"]
     with pytest.raises(MinydraWrongArgumentException):
-        Parser.map_args(args, False, False)
+        Parser.map_argv(args, False, False)
 
 
-def test_map_args_positive_flag():
+def test_map_argv_positive_flag():
     args = ["a", "b"]
-    assert Parser.map_args(args, False, False) == {"a": True, "b": True}
+    assert Parser.map_argv(args, False, False) == {"a": True, "b": True}
 
 
-def test_map_args_negative_flag():
+def test_map_argv_negative_flag():
     args = ["-a", "-b"]
-    assert Parser.map_args(args, False, False) == {"a": False, "b": False}
+    assert Parser.map_argv(args, False, False) == {"a": False, "b": False}
 
 
-def test_map_args_mixed_flags():
+def test_map_argv_mixed_flags():
     args = ["a", "-b"]
-    assert Parser.map_args(args, False, False) == {"a": True, "b": False}
+    assert Parser.map_argv(args, False, False) == {"a": True, "b": False}
 
 
 def test_set_env(monkeypatch, capfd):


### PR DESCRIPTION
* [x] automatically parse `minydra.Parser`'s  `__init__` keyword arguments from the command-line
* [x] add tests
* [x] add docstrings
* [x] add documentation

## Tests

Relevant additional tests:

```python
# test_minydra.py

def test_auto_kwargs():
    examples = Path(__file__).resolve().parent.parent / "examples"
    d1 = examples / "demo.json"
    with patch.object(
        sys,
        "argv",
        [
            "",
            "@verbose=1",
            "@allow_overwrites=True",
            "@warn_overwrites=False",
            "@parse_env=False",
            "@warn_env=False",
            f"@defaults={str(d1)}",
            "@strict=False",
            "@keep_special_kwargs=False",
            "new_key=3",
        ],
    ):
        parser = minydra.Parser(
            verbose=0,
            allow_overwrites=False,
            warn_overwrites=True,
            parse_env=True,
            warn_env=True,
            defaults=None,
            strict=True,
            keep_special_kwargs=True,
        )
        args = parser.args.resolve()

        assert parser.conf.verbose == 1
        assert parser.conf.allow_overwrites is True
        assert parser.conf.warn_overwrites is False
        assert parser.conf.parse_env is False
        assert parser.conf.warn_env is False
        assert parser.conf.strict is False
        assert parser.conf.keep_special_kwargs is False

        target = json.loads(d1.read_text())
        target["new_key"] = 3
        assert args.to_dict() == target

```